### PR TITLE
Block TryMask.com (anti-adblock service)

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -35,6 +35,9 @@
 @@||loxtk.com/gTemplate.php?GID=$subdocument,third-party
 @@||contentlockingnetworks.com/gLoader.php?GID=$script,third-party
 @@||contentlockingnetworks.com/gTemplate.php?GID=$subdocument,third-party
+!TrryMask.com (mask)
+https://trymask.com/api/v1/script/*
+###maskDisablePopup
 ! AdScendMedia
 ! if (gwloaded==false){window.location = "http://adscendmedia.com/gateway_adblock.php?p=4316";}
 ! https://adscendmedia.com/widget_adblock.php?p=12377 --> redirect
@@ -3436,4 +3439,6 @@ gaara-fr.com###pub01
 gaara-fr.com###ga-skin-left
 gaara-fr.com###ga-skin-right
 gaara-fr.com###ga-skin-top
+
+
 


### PR DESCRIPTION
These URLs are confirmed for Iframes. tested on http://www.getgrubbing.com/ (trymask.com demo site)

https://trymask.com/api/v1/script/widget
https://trymask.com/api/v1/script/popup
https://trymask.com/api/v1/script/banner

Visual Filter is here because otherwise there will be a [X] close button on the page.
